### PR TITLE
OSX: add homebrew lib directory to library paths on OSX

### DIFF
--- a/source/bindbc/freetype/dynload.d
+++ b/source/bindbc/freetype/dynload.d
@@ -39,7 +39,7 @@ FTSupport loadFreeType(){
 			"OSX": ["freetype.6"],
 		],
 		[
-			"OSX": ["/usr/X11/lib/", "/opt/X11/lib/", "/opt/homebrew/lib/"],
+			"OSX": ["/usr/X11/lib/", "/opt/X11/lib/"],
 		],
 	));
 	const(char)[][libNamesCT.length] libNames = libNamesCT;
@@ -61,19 +61,32 @@ FTSupport loadFreeType(const(char)* libName){
 	auto errCount = errorCount();
 	loadedVersion = FTSupport.badLibrary;
 	
-	static foreach(mod; [
-		"ft.advanc", "ft.bbox", "ft.bdf", "ft.bitmap", "ft.bzip2", "ft.cache",
+	version (linux) {
+	    enum optionalModules = ["ft.bdf"];
+	} else version (OSX) {
+	    enum optionalModules = ["ft.bdf"];
+	} else {
+	    enum optionalModules = []; 
+	}
+	enum moduleList = [
+		"ft.advanc", "ft.bbox", "ft.bitmap", "ft.bzip2", "ft.cache",
 		"ft.cid", "ft.color", "ft.driver", "ft.errdef", "ft.errors",
 		"ft.fntfmt", "ft.gasp", "ft.glyph", "ft.gxval", "ft.gzip", "ft.image",
 		"ft.increm", "ft.lcdfil", "ft.list", "ft.logging", "ft.lzw", "ft.mm",
-		"ft.modapi", "ft.moderr", "ft.otval", "ft.outln", "ft", "ft.params",
+		"ft.modapi", "ft.moderr", /* "ft.otval", */ "ft.outln", "ft", "ft.params",
 		"ft.pfr", "ft.render", "ft.sizes", "ft.snames", "ft.stroke",
 		"ft.synth", "ft.system", "ft.t1tables", "ft.trigon", "ft.ttnameid",
 		"ft.tttables", "ft.tttags", "ft.types", "ft.winfnt",
-	]){
+	];
+	static foreach(mod; moduleList){
+		mixin(mod ~ ".bindModuleSymbols(lib);");
+	}
+	static foreach(mod; optionalModules){
 		mixin(mod ~ ".bindModuleSymbols(lib);");
 	}
 	
-	if(errCount == errorCount()) loadedVersion = ftSupport; //this is a white-lie in order to maintain some backwards-compatibility :(
+	if(errCount == errorCount()) {
+	     loadedVersion = ftSupport; //this is a white-lie in order to maintain some backwards-compatibility :(
+        }
 	return loadedVersion;
 }

--- a/source/bindbc/freetype/dynload.d
+++ b/source/bindbc/freetype/dynload.d
@@ -39,7 +39,7 @@ FTSupport loadFreeType(){
 			"OSX": ["freetype.6"],
 		],
 		[
-			"OSX": ["/usr/X11/lib/", "/opt/X11/lib/"],
+			"OSX": ["/usr/X11/lib/", "/opt/X11/lib/", "/opt/homebrew/lib/"],
 		],
 	));
 	const(char)[][libNamesCT.length] libNames = libNamesCT;

--- a/source/ft/bdf.d
+++ b/source/ft/bdf.d
@@ -7,7 +7,6 @@
 +/
 module ft.bdf;
 
-version(linux):
 import bindbc.freetype.config;
 import bindbc.freetype.codegen;
 


### PR DESCRIPTION
OSX Sonoma arm64/m3 bindbc cannot find libfreetype installed with homebrew unless library path variable is set
```DYLD_LIBRARY_PATH=/opt/homebrew/lib```

Please let me know if there is some better way for adding the path.
Probably, better place is some common bindbc package?